### PR TITLE
Remove block args without affecting block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
 
 DEPENDENCIES

--- a/lib/avo_upgrade/upgrade29to30.rb
+++ b/lib/avo_upgrade/upgrade29to30.rb
@@ -43,7 +43,7 @@ module AvoUpgrade
         "|model, resource, view, field|",
         "|model, &args|"
       ]
-      remove_text_on(files_from(resources_path) + files_from(actions_path) + files_from(filters_path), remove_text)
+      remove_block_arg_on(files_from(resources_path) + files_from(actions_path) + files_from(filters_path), remove_text)
 
       print "\n\nUpgrade to Avo 3.0 completed! 🚀\n\n"
     end

--- a/test/avo_upgrade/upgrade_tool_test.rb
+++ b/test/avo_upgrade/upgrade_tool_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AvoUpgrade::UpgradeToolTest < ActiveSupport::TestCase
+  test 'remove_block_arg_on removes lambda args without removing args within the lambda' do
+    field_def = 'field :foobar, format_using: ->(value) { view_context.number_to_currency(value) }'
+    test_file = Tempfile.new('test_file')
+    test_file.write field_def
+    files = [test_file.path]
+    test_file.close
+    replace_array = ['(value)']
+    # expected_field_def = 'field :foobar, format_using: -> { view_context.number_to_currency(value) }'
+
+    AvoUpgrade::UpgradeTool.new.remove_block_arg_on(files, replace_array)
+    puts "clean"
+    updated_file_contents = File.read(test_file.path)
+    puts updated_file_contents
+    assert updated_file_contents == 'field :foobar, format_using: -> { view_context.number_to_currency(value) }'
+
+    test_file.unlink
+  end
+end


### PR DESCRIPTION
Update the regex used to remove block (proc/lambda) args so that it does not remove arguments to method calls inside of the lambda itself.

closes #3 